### PR TITLE
小修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ QQ Connect SDK for Ruby Framework
 
 `bundle install`
 
+最后
+
+`require 'qq'`
 ### 完整示例:
 1. 在 [QQ互联开放平台](https://connect.qq.com/) 申请 APP_ID 和 APP_KEY,并设置网站地址和回调域.
 2. 下载 demo 文件夹.
@@ -21,6 +24,13 @@ QQ Connect SDK for Ruby Framework
 
 相关参数请查阅[QQ互联开放平台](http://connect.qq.com/intro/login/)
 
+#### 在Rails中使用
+默认读取的是当前工作目录下的`qq_secrets.yml`，可通过更改当前工作目录的方式，读取其他位置的配置文件
+```
+Dir.chdir(Rails.root+'config')
+require 'qq'
+```
+以上代码是读取**Rails**项目**config**下的`qq_secrets.yml`配置文件
 
 ### 授权:
 

--- a/demo/sinatra/index.rb
+++ b/demo/sinatra/index.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require 'Qq'
+require 'qq'
 
 set :bind, 'YOUR SITE'
 enable :sessions


### PR DESCRIPTION
1. 将示例中的`require 'Qq'`更改为了`require 'qq'`，在区分大小写的操作系统上，前者可能会导致无法引入
2. 添加了在Rails中的使用说明，可以通过更改当前工作目录的方式来加载指定路径的`qq_qq_secrets.yml`配置文件